### PR TITLE
Implement typesafe routing and params

### DIFF
--- a/examples/starter/src/pages/home.tsx
+++ b/examples/starter/src/pages/home.tsx
@@ -33,18 +33,20 @@ function HomePage() {
   const { data, state } = homeRoute.useLoaderData();
   const { navigate } = useRouterContext();
 
-  // Test type safety - these should show autocomplete for valid routes
-  const testNavigate = () => {
-    // This should work
-    navigate({ url: "/about/:id", params: { id: 1 } });
-
-    // This should also work (no params route)
-    navigate({ url: "/" });
-
-    // Now let's test with a route that doesn't match the expected pattern
-    // navigate({ url: "/about/:id", params: { wrongParam: 1 } }); // This should error because wrongParam doesn't match the expected id
-    // navigate({ url: "/about/:id" }); // This should error because params are missing
+  // Type-safe navigation examples
+  const handleValidNavigation = () => {
+    // ✅ These work correctly with type safety
+    navigate({ url: "/" }); // Valid route without params
+    navigate({ url: "/about/:id", params: { id: 1 } }); // Valid route with correct params
   };
+
+  // ❌ These would cause TypeScript errors (uncomment to test):
+  // navigate({ url: "/nonexistent" }); // Error: route doesn't exist
+  // navigate({ url: "/about/:id" }); // Error: missing required params
+  // navigate({ url: "/about/:id", params: { wrongParam: 1 } }); // Error: wrong parameter name
+  // navigate({ url: "/about/:id", params: { id: "string" } }); // Error: wrong parameter type
+  // navigate({ url: "/about/:id", params: { id: 1, extra: "value" } }); // Error: extra parameters
+  // navigate({ url: "/", params: { something: "value" } }); // Error: params for non-dynamic route
 
   return (
     <>
@@ -53,11 +55,26 @@ function HomePage() {
         <span className="text-center tracking-tighter">Effect Router</span>
       </div>
       <h2>Home - {state === "loaded" ? data.hi : "loading"}</h2>
-      <button
-        onClick={() => navigate({ url: "/about/:id", params: { id: 1 } })}
-      >
-        Go To About 1
-      </button>
+      <div className="space-y-2">
+        <button
+          onClick={() => navigate({ url: "/about/:id", params: { id: 1 } })}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        >
+          Go To About 1
+        </button>
+        <button 
+          onClick={() => navigate({ url: "/" })}
+          className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
+        >
+          Go To Home
+        </button>
+        <button 
+          onClick={handleValidNavigation}
+          className="px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600"
+        >
+          Test Type Safety
+        </button>
+      </div>
     </>
   );
 }

--- a/examples/starter/tsconfig.json
+++ b/examples/starter/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "typeRoots": ["./node_modules/@types", "./src/router/effect-router.d.ts"],
+    "typeRoots": ["./node_modules/@types"],
     "plugins": [
       {
         "name": "@effect/language-service"

--- a/packages/router/src/Link.tsx
+++ b/packages/router/src/Link.tsx
@@ -1,17 +1,13 @@
 import { ComponentProps, MouseEvent } from "react";
 import { useRouterContext } from "./routerHooks";
-import { DynamicRoute, NavigableRoutes, ParamsForPath } from "./types";
+import { KnownRoutes, TypedLinkProps } from "./types";
 
-export function Link<Path extends NavigableRoutes["path"]>({
+export function Link<Path extends KnownRoutes>({
   onClick,
   href,
   params,
   ...props
-}: Omit<ComponentProps<"a">, "href"> & {
-  href: Path;
-} & (Path extends DynamicRoute
-    ? { params: ParamsForPath<Path> }
-    : { params?: never })) {
+}: Omit<ComponentProps<"a">, "href"> & TypedLinkProps<Path>) {
   const url =
     params == null
       ? href

--- a/packages/router/src/RouterProvider.tsx
+++ b/packages/router/src/RouterProvider.tsx
@@ -5,9 +5,9 @@ import { routeParser } from "./routeParser";
 import { LoaderResult } from "./routerTypes";
 import {
   BaseRoute,
-  DynamicRoute,
   isDynamicRoute,
-  ParamsForPath,
+  KnownRoutes,
+  TypedNavigateOptions,
 } from "./types";
 import { RouterContext } from "./routerHooks";
 
@@ -93,12 +93,8 @@ export function RouterProvider<T extends readonly BaseRoute[]>({
     handleRouteChange();
   }
 
-  function navigate<Path extends string>({
-    url,
-    params,
-  }: Path extends DynamicRoute
-    ? { url: Path; params: ParamsForPath<Path> }
-    : { url: Path; params?: never }) {
+  function navigate<Path extends KnownRoutes>(options: TypedNavigateOptions<Path>) {
+    const { url, params } = options;
     const parsedUrl =
       params == null
         ? url

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -3,3 +3,4 @@ export * from "./routerHooks";
 export * from "./routerTypes";
 export * from "./defineRoute";
 export * from "./types";
+export * from "./Link";

--- a/packages/router/src/routerHooks.ts
+++ b/packages/router/src/routerHooks.ts
@@ -1,20 +1,15 @@
 import { createContext, useContext } from "react";
 import {
   BaseRoute,
-  DynamicRoute,
-  ParamsForPath,
+  KnownRoutes,
+  TypedNavigateOptions,
 } from "./types";
 import { LoaderResult } from "./routerTypes";
 
 export const RouterContext = createContext<{
   matchedRoutes: BaseRoute[];
   goToUrl: (url: string) => void;
-  navigate<Path extends string>({
-    url,
-    params,
-  }: { url: Path } & (Path extends DynamicRoute
-    ? { params: ParamsForPath<Path> }
-    : { params?: never })): void;
+  navigate<Path extends KnownRoutes>(options: TypedNavigateOptions<Path>): void;
   rawParams: Record<string, string>;
   loaderData: LoaderResult<unknown>[];
 }>({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,15 +9,6 @@ catalogs:
     '@effect/language-service':
       specifier: ^0.27.2
       version: 0.27.2
-    '@effect/opentelemetry':
-      specifier: ^0.54.1
-      version: 0.54.1
-    '@effect/platform':
-      specifier: ^0.88.2
-      version: 0.88.2
-    '@effect/rpc':
-      specifier: ^0.65.2
-      version: 0.65.2
     effect:
       specifier: ^3.16.16
       version: 3.16.16
@@ -93,23 +84,14 @@ importers:
 
   packages/router:
     dependencies:
-      '@effect/opentelemetry':
-        specifier: catalog:effect
-        version: 0.54.1(@effect/platform@0.88.2(effect@3.16.16))(@opentelemetry/semantic-conventions@1.36.0)(effect@3.16.16)
-      '@effect/platform':
-        specifier: catalog:effect
-        version: 0.88.2(effect@3.16.16)
-      '@effect/rpc':
-        specifier: catalog:effect
-        version: 0.65.2(@effect/platform@0.88.2(effect@3.16.16))(effect@3.16.16)
       effect:
-        specifier: catalog:effect
+        specifier: ^3.16.16
         version: 3.16.16
       react:
-        specifier: ^19.1.0
+        specifier: '>=18.0.0 <20.0.0'
         version: 19.1.0
       react-dom:
-        specifier: ^19.1.0
+        specifier: '>=18.0.0 <20.0.0'
         version: 19.1.0(react@19.1.0)
       zod:
         specifier: ^3.25.76
@@ -155,46 +137,6 @@ packages:
   '@effect/language-service@0.27.2':
     resolution: {integrity: sha512-AFgxoIZ6xpfwCZp7+1mj3f1HsK3Yqe9I0iUfpf8Iu2gl9F3dmdFiOvuoLRVSkfVsK2BTQr8kv2zPi53Lst2haw==}
     hasBin: true
-
-  '@effect/opentelemetry@0.54.1':
-    resolution: {integrity: sha512-R4QecKh4Z6ATpBvo/JvBfMvdVNNeKtMsD9cSv1YiDoOEV3FrT35GKgmqkR5CC2a7iTSg4Z7pwG7ukqYpm2c1yQ==}
-    peerDependencies:
-      '@effect/platform': ^0.88.1
-      '@opentelemetry/api': ^1.9
-      '@opentelemetry/resources': ^2.0.0
-      '@opentelemetry/sdk-logs': '*'
-      '@opentelemetry/sdk-metrics': ^2.0.0
-      '@opentelemetry/sdk-trace-base': ^2.0.0
-      '@opentelemetry/sdk-trace-node': ^2.0.0
-      '@opentelemetry/sdk-trace-web': ^2.0.0
-      '@opentelemetry/semantic-conventions': ^1.33.0
-      effect: ^3.16.14
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@opentelemetry/resources':
-        optional: true
-      '@opentelemetry/sdk-logs':
-        optional: true
-      '@opentelemetry/sdk-metrics':
-        optional: true
-      '@opentelemetry/sdk-trace-base':
-        optional: true
-      '@opentelemetry/sdk-trace-node':
-        optional: true
-      '@opentelemetry/sdk-trace-web':
-        optional: true
-
-  '@effect/platform@0.88.2':
-    resolution: {integrity: sha512-JnPCfQz1y8ZED2OBxU82iFBT43fXrl26N+PEFtLWn1EedG6C6AwFvwbpFkICF3G2Qj/ZZ153xZaAxtVOPu4WTg==}
-    peerDependencies:
-      effect: ^3.16.16
-
-  '@effect/rpc@0.65.2':
-    resolution: {integrity: sha512-YRd9D5+1k5kniaAFbboEYbMH/jew8LmWMOS0C3s1w5ORqVQ5jggLIW0j3jpz/hofFLCQcNxiuSU1sP/a1k3pUg==}
-    peerDependencies:
-      '@effect/platform': ^0.88.1
-      effect: ^3.16.14
 
   '@esbuild/aix-ppc64@0.25.7':
     resolution: {integrity: sha512-uD0kKFHh6ETr8TqEtaAcV+dn/2qnYbH/+8wGEdY70Qf7l1l/jmBUbrmQqwiPKAQE6cOQ7dTj6Xr0HzQDGHyceQ==}
@@ -427,36 +369,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
-    cpu: [x64]
-    os: [win32]
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -468,10 +380,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@opentelemetry/semantic-conventions@1.36.0':
-    resolution: {integrity: sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==}
-    engines: {node: '>=14'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1005,9 +913,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-my-way-ts@0.1.6:
-    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1210,16 +1115,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.3:
-    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
-    hasBin: true
-
-  msgpackr@1.11.5:
-    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
-
-  multipasta@0.2.7:
-    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1227,10 +1122,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  node-gyp-build-optional-packages@5.2.2:
-    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
-    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1485,25 +1376,6 @@ snapshots:
 
   '@effect/language-service@0.27.2': {}
 
-  '@effect/opentelemetry@0.54.1(@effect/platform@0.88.2(effect@3.16.16))(@opentelemetry/semantic-conventions@1.36.0)(effect@3.16.16)':
-    dependencies:
-      '@effect/platform': 0.88.2(effect@3.16.16)
-      '@opentelemetry/semantic-conventions': 1.36.0
-      effect: 3.16.16
-
-  '@effect/platform@0.88.2(effect@3.16.16)':
-    dependencies:
-      '@opentelemetry/semantic-conventions': 1.36.0
-      effect: 3.16.16
-      find-my-way-ts: 0.1.6
-      msgpackr: 1.11.5
-      multipasta: 0.2.7
-
-  '@effect/rpc@0.65.2(@effect/platform@0.88.2(effect@3.16.16))(effect@3.16.16)':
-    dependencies:
-      '@effect/platform': 0.88.2(effect@3.16.16)
-      effect: 3.16.16
-
   '@esbuild/aix-ppc64@0.25.7':
     optional: true
 
@@ -1657,24 +1529,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1686,8 +1540,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
-
-  '@opentelemetry/semantic-conventions@1.36.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -2208,8 +2060,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-my-way-ts@0.1.6: {}
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2365,32 +2215,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.3:
-    dependencies:
-      node-gyp-build-optional-packages: 5.2.2
-    optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
-    optional: true
-
-  msgpackr@1.11.5:
-    optionalDependencies:
-      msgpackr-extract: 3.0.3
-
-  multipasta@0.2.7: {}
-
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
-
-  node-gyp-build-optional-packages@5.2.2:
-    dependencies:
-      detect-libc: 2.0.4
-    optional: true
 
   optionator@0.9.4:
     dependencies:


### PR DESCRIPTION
Add comprehensive type-safe navigation to `effect-router` to prevent invalid route and parameter usage at compile time.

Previously, `Link` and `navigate` functions allowed any string for URLs and did not validate parameters against route definitions, leading to potential runtime errors. This PR introduces explicit type mapping for routes and their parameters, ensuring that only valid routes with correct parameter types can be used, significantly improving developer experience and refactoring safety.